### PR TITLE
jsonp support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The Koala framework adds to Koa:
   - CSRF protection
 - [Polyfills](docs/polyfills.md) - serve polyfill bundles based on the user agent
 - [Response Caching](docs/response-caching.md) - cache and serve responses using an arbitrary store
+- [JSONP](docs/jsonp.md) - safe jsonp support
 - [Security Headers](docs/headers.md)
 - [Error Page](docs/error-page.md) - better default error page
 - [Tracing](docs/tracing.md)

--- a/docs/jsonp.md
+++ b/docs/jsonp.md
@@ -1,0 +1,29 @@
+
+## JSONP
+
+Koala use [koa-safe-jsonp](https://github.com/koajs/koa-safe-jsonp) for JSONP response.
+
+By default, `jsonp` is disabled.
+To enable `jsonp`, install set `options.jsonp = {jsonp options}` at initialization.
+See [jsonp options](https://github.com/koajs/koa-safe-jsonp).
+
+```js
+var app = koala({
+  jsonp: {
+    callback: 'callback'
+  }
+})
+```
+
+### this.jsonp
+
+Send the jsonp response.
+
+```js
+app.use(function* () {
+  this.jsonp = { name: 'fengmk2' }
+})
+```
+
+Koala will handle all the security problems,
+like [CVE-2014-4671](http://miki.it/blog/2014/7/8/abusing-jsonp-with-rosetta-flash/).

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,6 +36,11 @@ module.exports = function koala(options) {
     app.querystring = require('qs');
   }
 
+  // jsonp support
+  if (options.jsonp) {
+    require('koa-safe-jsonp')(app, options.jsonp);
+  }
+
   if (process.env.NODE_ENV !== 'production') app.debug();
 
   return app;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "koa-normalize": "0",
     "koa-spdy-push": "0",
     "koa-polyfills": "0",
+    "koa-safe-jsonp": "0",
     "koa-file-server": "2",
     "koa-body-parsers": "1",
     "koa-response-time": "1"

--- a/test/app/jsonp.js
+++ b/test/app/jsonp.js
@@ -1,0 +1,34 @@
+
+describe('jsonp', function () {
+  it('should return jsonp response', function (done) {
+    var app = koala({
+      jsonp: {
+        callback: '_callback'
+      }
+    })
+    app.use(function* (next) {
+      this.jsonp = {foo: 'bar'}
+    })
+
+    request(app.listen())
+    .get('/user.json?_callback=fn')
+    .expect(200)
+    .expect('/**/ typeof fn === \'function\' && fn({"foo":"bar"});', done)
+  })
+
+  it('should return json response', function (done) {
+    var app = koala({
+      jsonp: {
+        callback: '_callback'
+      }
+    })
+    app.use(function* (next) {
+      this.jsonp = {foo: 'bar'}
+    })
+
+    request(app.listen())
+    .get('/user.json')
+    .expect(200)
+    .expect('{"foo":"bar"}', done)
+  })
+})


### PR DESCRIPTION
``` js
var app = koala({
  jsonp: {
    callback: 'callback'
  }
})

app.use(function* () {
  this.jsonp = { name: 'fengmk2' }
})
```
- safe response

```
/**/ typeof fn === 'function' && fn({"foo":"bar"});
```
