### PR TITLE
session maxAge doc fix.

### DIFF
--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -16,7 +16,7 @@ See [koa-session](https://github.com/koajs/session) for all the options.
 ```js
 var app = koala({
   session: {
-    maxAge: '2 weeks'
+    maxAge: 14*24*60*60*1000 // 2 weeks
   }
 })
 ```


### PR DESCRIPTION
neither koa-session nor cookies have human-readable time parse function.
this will take people new to koala to  a wrong way.
