### PR TITLE
Also test on Node/io versions 3 to 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: node_js
 node_js:
-  - "1"
-  - "2"
+  - 1
+  - 2
+  - 3
+  - 4
+  - 5
+  - 6
+  - 7
+  - 8
 sudo: false
 script: "npm run test-travis"
 after_script: "npm install coveralls@2 && cat ./coverage/lcov.info | coveralls"


### PR DESCRIPTION
This adds Node LTS versions 4 and 6, the current stable 8 which will become an LTS next month, and some other Node/io versions that also pass (which we can remove if we need to break them while upgrading to Koa 2).

https://github.com/nodejs/LTS