### PR TITLE
Update npm before installing build dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - 6
   - 8
 sudo: false
+before_install: "npm install --global npm"
 script: "npm run test-travis"
 after_script: "npm install coveralls@2 && cat ./coverage/lcov.info | coveralls"
 notifications:


### PR DESCRIPTION
This could theoretically fix build issues by forcing older versions of Node to use npm 5+, which supports the lock file.